### PR TITLE
Add 'npm run package' script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 extension.zip
+source.zip
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Twitter Required Alt Text Chrome Extension
 
 This is a (in-progress) Chrome extension that will prevent you from tweeting images if you did not add alt text.
+
+To build: `npm run build`
+
+To package for upload: `npm run package`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Brandon Dail <brandon.dail@discordapp.com>",
   "license": "MIT",
   "scripts": {
-    "build": "rm extension/script.js && tsc --p tsconfig.json"
+    "build": "rm extension/script.js && tsc --p tsconfig.json",
+    "package": "rm -f source.zip extension.zip && zip -r source.zip . && cd extension && zip -r ../extension.zip ."
   },
   "devDependencies": {
     "typescript": "^3.9.7"


### PR DESCRIPTION
Adds `npm run package`, which zips up both the extension into `extension.zip` and the whole repo into `source.zip`. Source code was required by Mozilla since the extension js file is generated from typescript. Also documents both the build and package scripts in the readme.